### PR TITLE
set version in pom.xml from git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@
 name: "release"
 on:
   push:
-    # Sequence of patterns matched against refs/tags
+    # Run for tagged commits, the tag name should be X.Y.Z to be used as version in pom.xml
     tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - '[1-9]*'
 
 jobs:
   publish:
@@ -26,6 +26,11 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+      - name: "get version from git tag"
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: "Set version in pom.xml to ${{ steps.get_version.outputs.VERSION }}"
+        run: "mvn versions:set -DnewVersion=${{ steps.get_version.outputs.VERSION }} ; mvn versions:commit"
       - name: "Compile and package"
         run: mvn -B -DskipTests clean install
       - name: "Create Release"

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>cz.muni</groupId>
     <artifactId>aphos</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>aphos</name>
     <description>Amateur Photometric Survey</description>
     <properties>


### PR DESCRIPTION
Automatically set the project version in pom.xml from git tag name. The version is reported when the Spring Boot application starts to easily find which version is run.